### PR TITLE
Increase flexibility of create_animation.py as a python function

### DIFF
--- a/src/simpleitk_timeseries_motion_correction/create_animation.py
+++ b/src/simpleitk_timeseries_motion_correction/create_animation.py
@@ -166,7 +166,7 @@ def generate_animation(first_img, output_file, additional_input_imgs=None, label
         labels = [os.path.basename(label) if os.path.isfile(label) else str(label) for label in labels]
 
     # Get array (t, z, y, x) or (z, y, x)
-    arr = sitk.GetArrayFromImage(first_img)
+    arr = sitk.GetArrayViewFromImage(first_img)
 
     # Get Spacing (x, y, z) -> need (z, y, x)
     spacing_xyz = first_img.GetSpacing()
@@ -182,7 +182,7 @@ def generate_animation(first_img, output_file, additional_input_imgs=None, label
     additional_arrs = []
     if additional_input_imgs:
         for img_add in additional_input_imgs:
-            arr_add = sitk.GetArrayFromImage(img_add)
+            arr_add = sitk.GetArrayViewFromImage(img_add)
             if arr_add.ndim == 3:
                 arr_add = arr_add[np.newaxis, ...]
             print(f"Additional Data shape: {arr_add.shape}")
@@ -276,8 +276,9 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    print(f"Loading input images...")
+    print("Loading input images...")
     first_img = sitk.ReadImage(args.input) # load as SITK image
-    additional_input_imgs = [sitk.ReadImage(f) for f in args.additional_row] # create list of SITK images
+    # create list of SITK images
+    additional_input_imgs = [sitk.ReadImage(f) for f in args.additional_row] if args.additional_row else None
 
     generate_animation(first_img, args.output, additional_input_imgs, args.labels, args.scale, args.fps)

--- a/src/simpleitk_timeseries_motion_correction/create_animation.py
+++ b/src/simpleitk_timeseries_motion_correction/create_animation.py
@@ -171,7 +171,8 @@ def main(input_img, output_file, additional_input_imgs=None, labels=None, scale=
     elif os.path.isfile(input_img):
         print(f"Loading {input_img}...")
         img = sitk.ReadImage(input_img)
-
+    else:
+        raise ValueError(f"input_img must be a sitk.Image or a valid file path, got: {input_img}")
 
     # Get array (t, z, y, x) or (z, y, x)
     arr = sitk.GetArrayFromImage(img)
@@ -191,11 +192,15 @@ def main(input_img, output_file, additional_input_imgs=None, labels=None, scale=
     if additional_input_imgs:
         for img_add in additional_input_imgs:
             # the input can be either a nifti file or an SITK image
+            img_identifier = img_add if isinstance(img_add, str) else repr(img_add)
             if isinstance(img_add, sitk.Image):
-                img_add = img_add
+                pass  # Already a sitk.Image
             elif os.path.isfile(img_add):
-                print(f"Loading second input {img_add}...")
-                img_add = sitk.ReadImage(img_add)
+                 fname = img_add
+                 print(f"Loading second input {img_add}...")
+                 img_add = sitk.ReadImage(img_add)
+            else:
+                raise ValueError(f"additional_input_imgs entries must be sitk.Image or valid file paths, got: {img_add}")
 
             arr_add = sitk.GetArrayFromImage(img_add)
             if arr_add.ndim == 3:
@@ -203,7 +208,7 @@ def main(input_img, output_file, additional_input_imgs=None, labels=None, scale=
             print(f"Additional Data shape: {arr_add.shape}")
             if arr_add.shape != arr.shape:
                 print(
-                    f"WARNING: Shape of {img_add} does not match exactly. Proceeding with assumption that dimensions are compatible for slicing."
+                    f"WARNING: Shape of {img_identifier} does not match exactly. Proceeding with assumption that dimensions are compatible for slicing."
                 )
             additional_arrs.append(arr_add)
 


### PR DESCRIPTION
main() from create_animation.py is made more flexible for calling it as a python function, while SITK images may be already loaded in memory. It can now take either a SITK image or nifti file as input, and the labels can be customized as a list of strings or filenames.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animation creation now accepts in-memory image objects as well as file paths.
  * Added explicit axis label support via a new CLI option.

* **Breaking Changes**
  * Entry-point parameters and calling convention changed; update any integrations that invoke the tool.

* **Behavior Changes**
  * Labels are no longer auto-derived from filenames — provide labels explicitly when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->